### PR TITLE
Add task pane navigation shortcuts

### DIFF
--- a/src/Coralph.Tests/TuiStateTests.cs
+++ b/src/Coralph.Tests/TuiStateTests.cs
@@ -22,21 +22,88 @@ public class TuiStateTests
     public void SetTasksSnapshot_SelectsInProgressFirst()
     {
         var state = new TuiState();
-        var snapshot = new GeneratedTasksSnapshot(
-            Path: "generated_tasks.json",
-            Exists: true,
-            Error: null,
-            Tasks:
-            [
-                new GeneratedTaskSnapshotItem("001", 1, "Open task", "", "open", 1, 1),
-                new GeneratedTaskSnapshotItem("002", 1, "Active task", "", "in_progress", 2, 2),
-                new GeneratedTaskSnapshotItem("003", 1, "Done task", "", "done", 3, 3)
-            ],
-            ReadAtUtc: DateTimeOffset.UtcNow);
-
+        var snapshot = BuildSnapshotWithStatuses(["open", "in_progress", "done"]);
         state.SetTasksSnapshot(snapshot);
 
         Assert.Equal(1, state.GetTaskSelectedIndex(-1));
+    }
+
+    [Fact]
+    public void SetTasksSnapshot_ClampsSelectionAndScrollOnCountChange()
+    {
+        var state = new TuiState();
+        var initial = BuildSnapshotWithStatuses(["open", "open", "in_progress", "open", "open"]);
+        state.SetTasksSnapshot(initial);
+        state.SetTaskSelectedIndex(4);
+        state.SetTaskListScrollOffset(4);
+        state.EnsureTaskSelectionVisible(3);
+
+        var shrunk = BuildSnapshotWithStatuses(["done", "in_progress"]);
+        state.SetTasksSnapshot(shrunk);
+
+        Assert.Equal(1, state.GetTaskSelectedIndex(-1));
+        Assert.Equal(1, state.GetTaskListScrollOffset());
+
+        var expanded = BuildSnapshotWithStatuses(["open", "open", "open", "open", "open", "open", "open"]);
+        state.SetTasksSnapshot(expanded);
+
+        Assert.Equal(1, state.GetTaskSelectedIndex(-1));
+        Assert.Equal(1, state.GetTaskListScrollOffset());
+    }
+
+    [Fact]
+    public void SetTaskListScrollOffset_ClampsForEmptySmallAndLargeCollections()
+    {
+        var state = new TuiState();
+
+        state.SetTasksSnapshot(BuildSnapshotWithStatuses(Array.Empty<string>()));
+        state.SetTaskListScrollOffset(10, visibleRows: 5);
+        Assert.Equal(0, state.GetTaskListScrollOffset());
+        Assert.Equal(-1, state.GetTaskSelectedIndex(-1));
+
+        state.SetTasksSnapshot(BuildSnapshotWithStatuses(["open", "open"]));
+        state.SetTaskListScrollOffset(10, visibleRows: 5);
+        Assert.Equal(0, state.GetTaskListScrollOffset());
+
+        state.SetTasksSnapshot(BuildSnapshotWithStatuses(
+        [
+            "open", "open", "open", "open", "open", "open", "open", "open", "open", "open"
+        ]));
+        state.SetTaskListScrollOffset(10, visibleRows: 5);
+        Assert.Equal(5, state.GetTaskListScrollOffset());
+        state.SetTaskListScrollOffset(-7, visibleRows: 5);
+        Assert.Equal(0, state.GetTaskListScrollOffset());
+    }
+
+    [Fact]
+    public void TaskSelectionNavigation_UsesViewportForScrollOffsets()
+    {
+        var state = new TuiState();
+        state.SetTasksSnapshot(BuildSnapshotWithStatuses(["open", "open", "open", "open", "open", "open", "open", "open", "open", "open"]));
+
+        state.SelectFirstTask(3);
+        Assert.Equal(0, state.GetTaskSelectedIndex(-1));
+        Assert.Equal(0, state.GetTaskListScrollOffset());
+
+        state.MoveTaskSelection(9, 3);
+        Assert.Equal(9, state.GetTaskSelectedIndex(-1));
+        Assert.Equal(7, state.GetTaskListScrollOffset());
+
+        state.MoveTaskSelection(-1, 3);
+        Assert.Equal(8, state.GetTaskSelectedIndex(-1));
+        Assert.Equal(7, state.GetTaskListScrollOffset());
+
+        state.MoveTaskSelection(-2, 3);
+        Assert.Equal(6, state.GetTaskSelectedIndex(-1));
+        Assert.Equal(6, state.GetTaskListScrollOffset());
+
+        state.SelectFirstTask(3);
+        Assert.Equal(0, state.GetTaskSelectedIndex(-1));
+        Assert.Equal(0, state.GetTaskListScrollOffset());
+
+        state.SelectLastTask(3);
+        Assert.Equal(9, state.GetTaskSelectedIndex(-1));
+        Assert.Equal(7, state.GetTaskListScrollOffset());
     }
 
     [Fact]
@@ -121,5 +188,25 @@ public class TuiStateTests
         Assert.Equal(2, lines.Count);
         Assert.Contains("line-3", lines[0]);
         Assert.Contains("line-4", lines[1]);
+    }
+
+    private static GeneratedTasksSnapshot BuildSnapshotWithStatuses(string[] statuses)
+    {
+        return new GeneratedTasksSnapshot(
+            Path: "generated_tasks.json",
+            Exists: true,
+            Error: null,
+            Tasks:
+            [
+                .. statuses.Select((status, index) => new GeneratedTaskSnapshotItem(
+                    ((index + 1).ToString("000")),
+                    index + 1,
+                    $"Task {index + 1}",
+                    $"Description for task {index + 1}",
+                    status,
+                    index + 1,
+                    index + 1))
+            ],
+            ReadAtUtc: DateTimeOffset.UtcNow);
     }
 }

--- a/src/Coralph/Ui/Tui/Hex1bConsoleOutputBackend.cs
+++ b/src/Coralph/Ui/Tui/Hex1bConsoleOutputBackend.cs
@@ -309,12 +309,14 @@ internal sealed class Hex1bConsoleOutputBackend : IConsoleOutputBackend
         var exitPrompt = _state.GetExitPrompt();
         var transcriptLines = _state.GetTranscriptLines(maxLines: CalculateTranscriptVisibleLines());
         var tasksSnapshot = _state.GetTasksSnapshot();
+        var taskListVisibleRows = Math.Max(1, CalculateTaskListVisibleRows(tasksSnapshot.Tasks.Count));
+        _state.EnsureTaskSelectionVisible(taskListVisibleRows);
         var infoItems = new List<string> { "Coralph", "TUI" };
         if (_options.DemoMode)
         {
             infoItems.Add("DEMO");
         }
-        infoItems.AddRange(["Tasks", tasksSnapshot.Tasks.Count.ToString(), "Keys", "Ctrl+C exits"]);
+        infoItems.AddRange(["Tasks", tasksSnapshot.Tasks.Count.ToString(), "Task Nav", "k/j  Ctrl+U/Ctrl+D  gg/G (Home/End)", "Keys", "Ctrl+C exits"]);
         var doneItems = new List<string> { "Coralph", "TUI" };
         if (_options.DemoMode)
         {
@@ -332,12 +334,12 @@ internal sealed class Hex1bConsoleOutputBackend : IConsoleOutputBackend
                 r.WhenMinWidth(130, w => w.HStack(h =>
                 [
                     BuildTranscriptPane(h, transcriptLines).FillWidth(3),
-                    BuildTasksPane(h, tasksSnapshot).FillWidth(2)
+                    BuildTasksPane(h, tasksSnapshot, taskListVisibleRows).FillWidth(2)
                 ]).Fill()),
                 r.Otherwise(w => w.VStack(stack =>
                 [
                     BuildTranscriptPane(stack, transcriptLines).FillHeight(3),
-                    BuildTasksPane(stack, tasksSnapshot).FillHeight(2)
+                    BuildTasksPane(stack, tasksSnapshot, taskListVisibleRows).FillHeight(2)
                 ]).Fill())
             ]).FillHeight()
         ]).WithInputBindings(bindings =>
@@ -348,6 +350,19 @@ internal sealed class Hex1bConsoleOutputBackend : IConsoleOutputBackend
                 ConsoleOutput.RequestStop();
                 actionCtx.RequestStop();
             }, "Stop Coralph");
+
+            if (tasksSnapshot.Tasks.Count > 0)
+            {
+                var listRows = Math.Max(1, taskListVisibleRows);
+                bindings.Key(Hex1bKey.K).Global().Action(_ => HandleTaskSelection(-1, listRows), "Previous task");
+                bindings.Key(Hex1bKey.J).Global().Action(_ => HandleTaskSelection(1, listRows), "Next task");
+                bindings.Ctrl().Key(Hex1bKey.U).Global().Action(_ => HandleTaskSelection(-listRows, listRows), "Previous task page");
+                bindings.Ctrl().Key(Hex1bKey.D).Global().Action(_ => HandleTaskSelection(listRows, listRows), "Next task page");
+                bindings.Key(Hex1bKey.G).Then().Key(Hex1bKey.G).Global().Action(_ => HandleTaskFirst(listRows), "First task");
+                bindings.Key(Hex1bKey.G).Global().Action(_ => HandleTaskLast(listRows), "Last task");
+                bindings.Key(Hex1bKey.Home).Global().Action(_ => HandleTaskFirst(listRows), "First task");
+                bindings.Key(Hex1bKey.End).Global().Action(_ => HandleTaskLast(listRows), "Last task");
+            }
 
             if (exitPrompt is not null)
             {
@@ -395,7 +410,7 @@ internal sealed class Hex1bConsoleOutputBackend : IConsoleOutputBackend
         return ctx.Border(ctx.WithClipping(ctx.Text(transcriptText).Fill())).Title("Run Transcript");
     }
 
-    private Hex1bWidget BuildTasksPane<TParent>(WidgetContext<TParent> ctx, GeneratedTasksSnapshot snapshot)
+    private Hex1bWidget BuildTasksPane<TParent>(WidgetContext<TParent> ctx, GeneratedTasksSnapshot snapshot, int visibleTaskRows)
         where TParent : Hex1bWidget
     {
         if (!snapshot.Exists)
@@ -426,21 +441,42 @@ internal sealed class Hex1bConsoleOutputBackend : IConsoleOutputBackend
         }
 
         var contentWidth = CalculateTasksPaneContentWidth();
-        var activeIndex = snapshot.ActiveTaskIndex();
-        var activeTask = snapshot.Tasks[activeIndex];
+        var activeTaskIndex = _state.GetTaskSelectedIndex(snapshot.ActiveTaskIndex());
+        if (activeTaskIndex < 0 || activeTaskIndex >= snapshot.Tasks.Count)
+        {
+            activeTaskIndex = snapshot.ActiveTaskIndex();
+            _state.SetTaskSelectedIndex(activeTaskIndex);
+        }
+
+        var activeTask = snapshot.Tasks[activeTaskIndex];
+        var clampedVisibleRows = Math.Max(1, Math.Min(visibleTaskRows, snapshot.Tasks.Count));
+        var scrollOffset = Math.Clamp(
+            _state.GetTaskListScrollOffset(),
+            0,
+            Math.Max(0, snapshot.Tasks.Count - clampedVisibleRows));
         var lines = new List<string>
         {
             "Current Task"
         };
+        var activeTaskLines = BuildTaskBlock(activeTask, contentWidth, isActive: true, includeDescription: true).ToList();
+        var maxCurrentTaskLines = Math.Max(1, CalculateTaskPaneContentHeight() / 3);
+        var visibleCurrentTaskLines = activeTaskLines.Take(maxCurrentTaskLines).ToList();
 
-        lines.AddRange(BuildTaskBlock(activeTask, contentWidth, isActive: true, includeDescription: true));
+        lines.AddRange(visibleCurrentTaskLines);
+        if (activeTaskLines.Count > visibleCurrentTaskLines.Count)
+        {
+            lines.Add("  ...");
+        }
         lines.Add(string.Empty);
         lines.Add("All Tasks");
 
-        for (var i = 0; i < snapshot.Tasks.Count; i++)
+        var startIndex = Math.Max(0, scrollOffset);
+        var endIndex = Math.Min(snapshot.Tasks.Count, startIndex + clampedVisibleRows);
+
+        for (var i = startIndex; i < endIndex; i++)
         {
-            lines.AddRange(BuildTaskBlock(snapshot.Tasks[i], contentWidth, isActive: i == activeIndex, includeDescription: false));
-            if (i < snapshot.Tasks.Count - 1)
+            lines.AddRange(BuildTaskBlock(snapshot.Tasks[i], contentWidth, isActive: i == activeTaskIndex, includeDescription: false));
+            if (i < endIndex - 1)
             {
                 lines.Add(string.Empty);
             }
@@ -448,6 +484,24 @@ internal sealed class Hex1bConsoleOutputBackend : IConsoleOutputBackend
 
         var tasksText = string.Join(Environment.NewLine, lines);
         return ctx.Border(ctx.WithClipping(ctx.Text(tasksText).Fill())).Title("Generated Tasks");
+    }
+
+    private void HandleTaskSelection(int delta, int visibleRows)
+    {
+        _state.MoveTaskSelection(delta, visibleRows);
+        RequestInvalidate();
+    }
+
+    private void HandleTaskFirst(int visibleRows)
+    {
+        _state.SelectFirstTask(visibleRows);
+        RequestInvalidate();
+    }
+
+    private void HandleTaskLast(int visibleRows)
+    {
+        _state.SelectLastTask(visibleRows);
+        RequestInvalidate();
     }
 
     private static IEnumerable<string> BuildTaskBlock(
@@ -610,6 +664,31 @@ internal sealed class Hex1bConsoleOutputBackend : IConsoleOutputBackend
 
         // Border consumes top and bottom rows.
         return Math.Max(1, transcriptPaneHeight - 2);
+    }
+
+    private static int CalculateTaskListVisibleRows(int taskCount)
+    {
+        if (taskCount <= 0)
+        {
+            return 1;
+        }
+
+        var paneHeight = CalculateTaskPaneContentHeight();
+        var reservedForCurrentTask = Math.Max(1, paneHeight / 3);
+        var availableRows = paneHeight - reservedForCurrentTask - 2;
+        return Math.Clamp(availableRows, 1, taskCount);
+    }
+
+    private static int CalculateTaskPaneContentHeight()
+    {
+        var width = ReadConsoleDimension(() => Console.WindowWidth, fallback: 120);
+        var height = ReadConsoleDimension(() => Console.WindowHeight, fallback: 40);
+        var bodyHeight = Math.Max(1, height - 1); // Info bar.
+        var paneHeight = width >= 130
+            ? bodyHeight
+            : Math.Max(1, (bodyHeight * 2) / 5);
+
+        return Math.Max(1, paneHeight - 2);
     }
 
     private static int ReadConsoleDimension(Func<int> reader, int fallback)

--- a/src/Coralph/Ui/Tui/TuiState.cs
+++ b/src/Coralph/Ui/Tui/TuiState.cs
@@ -21,6 +21,7 @@ internal sealed class TuiState
 
     private GeneratedTasksSnapshot _tasksSnapshot = GeneratedTasksSnapshot.Missing(TaskBacklog.DefaultBacklogFile);
     private int _taskSelectedIndex = -1;
+    private int _taskListScrollOffset;
 
     private PromptSelectionRequest? _prompt;
     private ExitPromptRequest? _exitPrompt;
@@ -88,6 +89,7 @@ internal sealed class TuiState
             if (snapshot.Tasks.Count == 0)
             {
                 _taskSelectedIndex = -1;
+                _taskListScrollOffset = 0;
                 return;
             }
 
@@ -95,6 +97,12 @@ internal sealed class TuiState
             {
                 _taskSelectedIndex = snapshot.ActiveTaskIndex();
             }
+            else
+            {
+                _taskSelectedIndex = Math.Clamp(_taskSelectedIndex, 0, snapshot.Tasks.Count - 1);
+            }
+
+            EnsureTaskSelectionVisible(1);
         }
     }
 
@@ -110,7 +118,113 @@ internal sealed class TuiState
     {
         lock (_lock)
         {
-            _taskSelectedIndex = index;
+            if (_tasksSnapshot.Tasks.Count == 0)
+            {
+                _taskSelectedIndex = -1;
+                return;
+            }
+
+            _taskSelectedIndex = Math.Clamp(index, 0, _tasksSnapshot.Tasks.Count - 1);
+        }
+    }
+
+    internal int GetTaskListScrollOffset()
+    {
+        lock (_lock)
+        {
+            return _taskListScrollOffset;
+        }
+    }
+
+    internal void SetTaskListScrollOffset(int scrollOffset, int visibleRows = 1)
+    {
+        lock (_lock)
+        {
+            _taskListScrollOffset = CalculateScrollOffset(scrollOffset, visibleRows);
+        }
+    }
+
+    internal void AdjustTaskListScrollOffset(int delta, int visibleRows = 1)
+    {
+        SetTaskListScrollOffset(_taskListScrollOffset + delta, visibleRows);
+    }
+
+    internal void EnsureTaskSelectionVisible(int visibleRows)
+    {
+        lock (_lock)
+        {
+            if (_tasksSnapshot.Tasks.Count == 0)
+            {
+                _taskSelectedIndex = -1;
+                _taskListScrollOffset = 0;
+                return;
+            }
+
+            var visibleTaskRows = Math.Max(1, visibleRows);
+            if (_taskSelectedIndex < 0)
+            {
+                _taskSelectedIndex = _tasksSnapshot.ActiveTaskIndex();
+            }
+
+            _taskSelectedIndex = Math.Clamp(_taskSelectedIndex, 0, _tasksSnapshot.Tasks.Count - 1);
+            _taskListScrollOffset = CalculateScrollOffset(_taskListScrollOffset, visibleTaskRows);
+
+            if (_taskSelectedIndex < _taskListScrollOffset)
+            {
+                _taskListScrollOffset = _taskSelectedIndex;
+            }
+            else if (_taskSelectedIndex >= _taskListScrollOffset + visibleTaskRows)
+            {
+                _taskListScrollOffset = Math.Max(0, _taskSelectedIndex - visibleTaskRows + 1);
+            }
+        }
+    }
+
+    internal void MoveTaskSelection(int delta, int visibleRows)
+    {
+        lock (_lock)
+        {
+            if (_tasksSnapshot.Tasks.Count == 0)
+            {
+                _taskSelectedIndex = -1;
+                _taskListScrollOffset = 0;
+                return;
+            }
+
+            _taskSelectedIndex = Math.Clamp(_taskSelectedIndex + delta, 0, _tasksSnapshot.Tasks.Count - 1);
+            EnsureTaskSelectionVisible(visibleRows);
+        }
+    }
+
+    internal void SelectFirstTask(int visibleRows)
+    {
+        lock (_lock)
+        {
+            if (_tasksSnapshot.Tasks.Count == 0)
+            {
+                _taskSelectedIndex = -1;
+                _taskListScrollOffset = 0;
+                return;
+            }
+
+            _taskSelectedIndex = 0;
+            EnsureTaskSelectionVisible(visibleRows);
+        }
+    }
+
+    internal void SelectLastTask(int visibleRows)
+    {
+        lock (_lock)
+        {
+            if (_tasksSnapshot.Tasks.Count == 0)
+            {
+                _taskSelectedIndex = -1;
+                _taskListScrollOffset = 0;
+                return;
+            }
+
+            _taskSelectedIndex = _tasksSnapshot.Tasks.Count - 1;
+            EnsureTaskSelectionVisible(visibleRows);
         }
     }
 
@@ -262,6 +376,18 @@ internal sealed class TuiState
             TranscriptEntryKind.Warning => "WARN",
             _ => "LOG"
         };
+    }
+
+    private int CalculateScrollOffset(int scrollOffset, int visibleRows)
+    {
+        if (_tasksSnapshot.Tasks.Count == 0)
+        {
+            return 0;
+        }
+
+        var visibleTaskRows = Math.Max(1, visibleRows);
+        var maxOffset = Math.Max(0, _tasksSnapshot.Tasks.Count - visibleTaskRows);
+        return Math.Clamp(scrollOffset, 0, maxOffset);
     }
 }
 


### PR DESCRIPTION
Summary
- wire task pane navigation to viewport-aware scrolling, selection, and instruction text
- add state tracking for selection and scroll offsets with clamping helpers and tests
- calculate visible rows dynamically so navigation and rendering stay consistent

closes #97 