### PR TITLE
docs: sync repository documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,12 +260,12 @@ See `./coralph --help` for all options.
 | `progress.txt` | Completed work log |
 | `coralph.config.json` | Configuration overrides |
 
-The loop stops when the AI outputs `COMPLETE` or no open issues remain.
+The loop stops when the AI outputs `COMPLETE`, `NO_OPEN_ISSUES`, or `ALL_TASKS_COMPLETE`.
 
 ---
 
 ## Extending Tech Stack Support
 
 1. Create `examples/<stack>-prompt.md` with build/test commands
-2. Update `--init` detection logic for your manifest files (see src/Coralph/Program.cs)
+2. Update `--init` detection logic for your manifest files (see src/Coralph/InitWorkflow.cs)
 3. Submit a PR – see [CONTRIBUTING.md](CONTRIBUTING.md)

--- a/coralph.config.json
+++ b/coralph.config.json
@@ -1,7 +1,7 @@
 {
   "LoopOptions": {
     "MaxIterations": 10,
-    "Model": "claude-sonnet-4.6",
+    "Model": "GPT-5.1-Codex",
     "ProviderType": null,
     "ProviderBaseUrl": null,
     "ProviderWireApi": null,
@@ -9,6 +9,7 @@
     "PromptFile": "prompt.md",
     "ProgressFile": "progress.txt",
     "IssuesFile": "issues.json",
+    "GeneratedTasksFile": "generated_tasks.json",
     "RefreshIssues": false,
     "Repo": null,
     "RefreshIssuesAzdo": false,
@@ -19,6 +20,8 @@
     "DockerSandbox": false,
     "DockerImage": "mcr.microsoft.com/devcontainers/dotnet:10.0",
     "ClientName": "coralph",
+    "ShowReasoning": true,
+    "ColorizedOutput": true,
     "ReasoningEffort": null
   }
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,9 +6,10 @@ This document describes the high-level architecture of Coralph, an AI-powered de
 
 Coralph is a .NET CLI application that orchestrates automated development workflows by:
 1. Reading GitHub issues and a prompt template
-2. Running an AI assistant (via GitHub Copilot SDK) in a loop
-3. Allowing the assistant to make changes, run tests, and commit code
-4. Tracking progress across iterations
+2. Building merged runtime configuration from CLI flags and `coralph.config.json`
+3. Running an AI assistant (via GitHub Copilot SDK) in a loop
+4. Allowing the assistant to make changes, run tests, and commit code
+5. Tracking progress across iterations and terminal signals
 
 ## Architecture Diagram
 
@@ -18,63 +19,94 @@ flowchart TD
         Main["Program.cs<br/>Entry Point"]
         ArgParser["ArgParser.cs<br/>Command Line Parsing"]
         Banner["Banner.cs<br/>ASCII Art & Version"]
+        WorkingDir["WorkingDirectoryContext.cs<br/>Repository Directory Resolution"]
     end
 
-    subgraph Core["Core Loop"]
-        LoopOptions["LoopOptions.cs<br/>Configuration"]
+    subgraph Config["Configuration"]
+        LoopOptions["LoopOptions.cs<br/>Defaults + Overrides"]
+        ConfigService["ConfigurationService.cs<br/>Config Loading + Merge"]
+        RuntimePrep["LoopOptionsRuntimePreparation.cs<br/>Runtime Validation"]
+    end
+
+    subgraph Core["Core Orchestration"]
+        Orchestrator["LoopOrchestrator.cs<br/>Iteration Lifecycle"]
         PromptHelpers["PromptHelpers.cs<br/>Prompt Assembly"]
-        CopilotRunner["CopilotRunner.cs<br/>AI Session Management"]
+        SessionRunner["CopilotSessionRunner.cs<br/>Persistent Copilot Session"]
+        Runner["CopilotRunner.cs<br/>One-shot Execution"]
+        TaskBacklog["TaskBacklog.cs<br/>Generated Task Sync"]
+        GitService["GitService.cs<br/>Progress Commit Helper"]
+        DockerSandbox["DockerSandbox.cs<br/>Containerized Iterations"]
     end
 
-    subgraph IO["I/O Layer"]
+    subgraph Output["Output / UI"]
         ConsoleOutput["ConsoleOutput.cs<br/>Output Facade"]
+        ConsoleSupervisor["ConsoleOutputSupervisor.cs<br/>Backend Lifecycle"]
         ClassicBackend["ClassicConsoleOutputBackend.cs<br/>Spectre Console Renderer"]
         TuiBackend["Hex1bConsoleOutputBackend.cs<br/>Hex1b Split-Pane TUI"]
         UiResolver["UiModeResolver.cs<br/>Mode Selection Logic"]
+        TerminalSignal["TerminalSignal.cs<br/>Loop Stop Signals"]
+    end
+
+    subgraph Support["Support"]
+        StartupValidation["StartupValidation.cs<br/>Prompt Validation"]
+        BacklogCleanup["BacklogCleanup.cs<br/>Backlog Cleanup Rules"]
         CustomTools["CustomTools.cs<br/>AI-Callable Tools"]
         GhIssues["GhIssues.cs<br/>GitHub CLI Integration"]
     end
 
     subgraph External["External Dependencies"]
-        CopilotSDK["GitHub.Copilot.SDK<br/>AI Runtime"]
-        Hex1b["Hex1b<br/>TUI Framework"]
-        ConfigJson["Microsoft.Extensions.Configuration<br/>JSON Config Loading"]
-        SpectreConsole["Spectre.Console<br/>Rich Terminal UI"]
-        SystemCommandLine["System.CommandLine<br/>CLI Parsing"]
+        CopilotSDK["GitHub.Copilot.SDK 0.1.32<br/>AI Runtime"]
+        Hex1b["Hex1b 0.83.0<br/>TUI Framework"]
+        ConfigJson["Microsoft.Extensions.Configuration.Json 8.0.0<br/>JSON Config Loading"]
+        SpectreConsole["Spectre.Console 0.49.1<br/>Rich Terminal UI"]
+        SystemCommandLine["System.CommandLine 2.0.0-beta4.22272.1<br/>CLI Parsing"]
     end
 
     subgraph Files["File System"]
         PromptMD["prompt.md<br/>Instructions Template"]
         IssuesJSON["issues.json<br/>GitHub Issues"]
-        ProgressTXT["progress.txt<br/>Learning Journal"]
+        GeneratedTasksJSON["generated_tasks.json<br/>Persisted Backlog"]
+        ProgressTXT["progress.txt<br/>Progress Journal"]
         ConfigFile["coralph.config.json<br/>Configuration Overrides"]
     end
 
     Main --> ArgParser
     Main --> Banner
-    Main --> LoopOptions
-    Main --> PromptHelpers
-    Main --> CopilotRunner
-    
+    Main --> WorkingDir
+    Main --> ConfigService
+    Main --> RuntimePrep
+    Main --> Orchestrator
+    Main --> UiResolver
+    Main --> ConfigFile
+
     ArgParser --> SystemCommandLine
-    LoopOptions --> ConfigJson
-    
-    CopilotRunner --> CopilotSDK
-    CopilotRunner --> CustomTools
-    CopilotRunner --> ConsoleOutput
+    ConfigService --> ConfigJson
+    ConfigService --> LoopOptions
+    RuntimePrep --> LoopOptions
+
+    Orchestrator --> PromptHelpers
+    Orchestrator --> TaskBacklog
+    Orchestrator --> SessionRunner
+    Orchestrator --> Runner
+    Orchestrator --> DockerSandbox
+    Orchestrator --> GitService
+    Orchestrator --> ConsoleOutput
+    Orchestrator --> TerminalSignal
+    Orchestrator --> BacklogCleanup
+    Orchestrator --> StartupValidation
+    Orchestrator --> CustomTools
+    Orchestrator --> GhIssues
+
+    ConsoleOutput --> ConsoleSupervisor
     ConsoleOutput --> ClassicBackend
     ConsoleOutput --> TuiBackend
-    Main --> UiResolver
     ClassicBackend --> SpectreConsole
     TuiBackend --> Hex1b
 
     PromptHelpers --> PromptMD
-    PromptHelpers --> IssuesJSON
+    TaskBacklog --> IssuesJSON
+    TaskBacklog --> GeneratedTasksJSON
     PromptHelpers --> ProgressTXT
-    
-    Main --> ConfigFile
-    Main --> GhIssues
-    GhIssues --> IssuesJSON
 ```
 
 ## Component Descriptions
@@ -83,26 +115,48 @@ flowchart TD
 
 | Component | Responsibility |
 |-----------|----------------|
-| **Program.cs** | Entry point, orchestrates the main loop, handles initialization and shutdown |
+| **Program.cs** | Entry point; resolves working directory, parses args, boots init or loop |
 | **ArgParser.cs** | Parses command-line arguments using System.CommandLine |
 | **Banner.cs** | Displays animated ASCII banner and version information |
+| **WorkingDirectoryContext.cs** | Resolves and applies `--working-dir` before the loop starts |
 
-### Core Loop
-
-| Component | Responsibility |
-|-----------|----------------|
-| **LoopOptions.cs** | Configuration model (max iterations, model, file paths, etc.) |
-| **PromptHelpers.cs** | Combines prompt template with issues and progress into a single prompt |
-| **CopilotRunner.cs** | Manages AI session lifecycle, handles streaming events and tool execution |
-
-### I/O Layer
+### Configuration
 
 | Component | Responsibility |
 |-----------|----------------|
-| **ConsoleOutput.cs** | Facade used by runtime code; routes output to classic or TUI backend |
-| **ClassicConsoleOutputBackend.cs** | Existing Spectre-based line output and styling |
+| **LoopOptions.cs** | Configuration defaults and override model |
+| **ConfigurationService.cs** | Loads JSON config and merges CLI args, config, and defaults |
+| **LoopOptionsRuntimePreparation.cs** | Applies runtime-only adjustments and validation |
+
+### Core Orchestration
+
+| Component | Responsibility |
+|-----------|----------------|
+| **LoopOrchestrator.cs** | Coordinates iterations, terminal signals, and exit handling |
+| **PromptHelpers.cs** | Builds the combined prompt from the template, issues, progress, and backlog |
+| **CopilotSessionRunner.cs** | Maintains a persistent Copilot session across iterations |
+| **CopilotRunner.cs** | Handles one-shot execution paths and fallbacks |
+| **TaskBacklog.cs** | Syncs `generated_tasks.json` from open issues |
+| **GitService.cs** | Commits progress updates when needed |
+| **DockerSandbox.cs** | Runs iterations inside a container when sandboxing is enabled |
+
+### Output / UI
+
+| Component | Responsibility |
+|-----------|----------------|
+| **ConsoleOutput.cs** | Facade used by runtime code; routes output to the active backend |
+| **ConsoleOutputSupervisor.cs** | Keeps the active backend healthy during long-running output |
+| **ClassicConsoleOutputBackend.cs** | Spectre-based line output and styling |
 | **Hex1bConsoleOutputBackend.cs** | Interactive split-pane TUI (transcript + generated tasks) |
 | **UiModeResolver.cs** | Resolves effective mode from `--ui`, `--stream-events`, and redirection state |
+| **TerminalSignal.cs** | Defines terminal stop markers such as `COMPLETE` and `NO_OPEN_ISSUES` |
+
+### Support
+
+| Component | Responsibility |
+|-----------|----------------|
+| **StartupValidation.cs** | Validates prompt and runtime prerequisites |
+| **BacklogCleanup.cs** | Determines when generated backlog files should be removed |
 | **CustomTools.cs** | Exposes AI-callable functions (list_open_issues, list_generated_tasks, get_progress_summary, search_progress) |
 | **GhIssues.cs** | Fetches issues from GitHub using `gh` CLI |
 
@@ -112,31 +166,27 @@ flowchart TD
 sequenceDiagram
     participant User
     participant CLI as Program.cs
-    participant Runner as CopilotRunner
+    participant Config as ConfigurationService
+    participant Runner as LoopOrchestrator
+    participant Tasks as TaskBacklog
     participant SDK as GitHub.Copilot.SDK
     participant Output as ConsoleOutput
-    participant Tools as CustomTools
+    participant Git as GitService
     participant Files as File System
 
     User->>CLI: coralph --max-iterations 10
-    CLI->>Files: Load prompt.md, issues.json, generated_tasks.json, progress.txt
-    CLI->>Runner: RunOnceAsync(combinedPrompt)
-    
+    CLI->>Files: Load prompt.md, issues.json, generated_tasks.json, progress.txt, coralph.config.json
+    CLI->>Config: Merge CLI args + config file + defaults
+    CLI->>Runner: RunAsync(LoopOptions)
+
     loop Each Iteration
-        Runner->>SDK: CreateSession + SendAsync
+        Runner->>Tasks: EnsureBacklogAsync()
+        Runner->>SDK: SendAsync(combinedPrompt)
         SDK->>Runner: Streaming events (delta, tool calls)
-        
-        opt Tool Execution
-            SDK->>Tools: list_open_issues / list_generated_tasks / get_progress_summary
-            Tools->>Files: Read issues.json / progress.txt
-            Tools-->>SDK: Return results
-        end
-        
         Runner-->>Output: Structured output events
-        Output-->>CLI: Render (classic or TUI)
-        CLI->>Files: Check for COMPLETE marker
+        Runner->>Git: CommitProgressIfNeededAsync()
     end
-    
+
     CLI-->>User: Exit with status
 ```
 
@@ -144,12 +194,12 @@ sequenceDiagram
 
 | Package | Version | Purpose |
 |---------|---------|---------|
-| **GitHub.Copilot.SDK** | 0.1.23 | AI runtime for Copilot integration |
+| **GitHub.Copilot.SDK** | 0.1.32 | AI runtime for Copilot integration |
 | **Hex1b** | 0.83.0 | Interactive split-pane TUI rendering |
 | **Microsoft.Extensions.Configuration.Json** | 8.0.0 | Load configuration from JSON files |
 | **Microsoft.Extensions.Options.ConfigurationExtensions** | 8.0.0 | Bind configuration to options classes |
 | **Spectre.Console** | 0.49.1 | Rich terminal output (colors, styling) |
-| **System.CommandLine** | 2.0.0-beta4 | CLI argument parsing and help generation |
+| **System.CommandLine** | 2.0.0-beta4.22272.1 | CLI argument parsing and help generation |
 
 ## File Dependencies
 
@@ -169,4 +219,4 @@ sequenceDiagram
 4. **Tool Extensibility**: Custom AI tools exposed via `AIFunctionFactory.Create()` pattern
 5. **Configuration Layering**: CLI args override config file, which overrides defaults
 6. **Progress as Learning Journal**: Assistant writes structured summaries with learnings, not raw output
-7. **Early Exit on COMPLETE**: Loop terminates when assistant outputs completion marker
+7. **Terminal Signals Are Validated**: `COMPLETE` is ignored while open backlog items remain; `NO_OPEN_ISSUES` and `ALL_TASKS_COMPLETE` also stop the loop

--- a/docs/using-with-other-repos.md
+++ b/docs/using-with-other-repos.md
@@ -140,20 +140,24 @@ coralph --working-dir /path/to/your/target/repo --max-iterations 10
 
 ### `coralph.config.json`
 
-Customize behavior for your repository:
+Customize behavior for your repository. The JSON binds to the `LoopOptions` section, using the same property names as `src/Coralph/LoopOptions.cs`.
 
 ```json
 {
-  "model": "gpt-4o",
-  "maxIterations": 10,
-  "maxTokens": 100000,
-  "issuesFile": "issues.json",
-  "promptFile": "prompt.md",
-  "progressFile": "progress.txt",
-  "refreshIssues": false,
-  "repo": "owner/repo-name",
-  "showReasoning": true,
-  "colorizedOutput": true
+  "LoopOptions": {
+    "MaxIterations": 10,
+    "Model": "GPT-5.1-Codex",
+    "PromptFile": "prompt.md",
+    "ProgressFile": "progress.txt",
+    "IssuesFile": "issues.json",
+    "GeneratedTasksFile": "generated_tasks.json",
+    "RefreshIssues": false,
+    "Repo": "owner/repo-name",
+    "ShowReasoning": true,
+    "ColorizedOutput": true,
+    "DockerSandbox": false,
+    "ClientName": "coralph"
+  }
 }
 ```
 
@@ -161,14 +165,23 @@ Customize behavior for your repository:
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `model` | `gpt-4o` | AI model to use |
-| `maxIterations` | `10` | Maximum loop iterations |
-| `promptFile` | `prompt.md` | Instructions file |
-| `issuesFile` | `issues.json` | GitHub issues cache |
-| `progressFile` | `progress.txt` | Progress tracking log |
-| `repo` | (required for `--refresh-issues`) | GitHub repo `owner/name` |
-| `showReasoning` | `true` | Display AI reasoning steps |
-| `colorizedOutput` | `true` | Use colored terminal output |
+| `Model` | `GPT-5.1-Codex` | AI model to use |
+| `MaxIterations` | `10` | Maximum loop iterations |
+| `GeneratedTasksFile` | `generated_tasks.json` | Generated task backlog file |
+| `PromptFile` | `prompt.md` | Instructions file |
+| `IssuesFile` | `issues.json` | GitHub issues cache |
+| `ProgressFile` | `progress.txt` | Progress tracking log |
+| `RefreshIssues` | `false` | Refresh issues before the loop starts |
+| `Repo` | (required for `--refresh-issues`) | GitHub repo `owner/name` |
+| `ShowReasoning` | `true` | Display AI reasoning steps |
+| `ColorizedOutput` | `true` | Use colored terminal output |
+| `DockerSandbox` | `false` | Run each iteration inside Docker |
+| `DockerImage` | `mcr.microsoft.com/devcontainers/dotnet:10.0` | Docker image for sandbox runs |
+| `ClientName` | `coralph` | Client name sent to the Copilot session |
+| `ReasoningEffort` | (model default) | Reasoning budget hint |
+| `ToolAllow` / `ToolDeny` | `[]` | Allow/deny lists for tool permissions |
+
+See `src/Coralph/LoopOptions.cs` for the full set of config keys, including provider settings, CLI paths, Azure Boards integration, list-models, demo mode, and dry-run support.
 
 ## Adapting `prompt.md` for Your Stack
 


### PR DESCRIPTION
## Summary
- Update README init guidance to point at InitWorkflow.cs and list all terminal stop markers.
- Refresh docs/architecture.md to match the current orchestration classes and dependency versions.
- Rewrite docs/using-with-other-repos.md so the config example and reference table match current LoopOptions fields.
- Align coralph.config.json with the current default model and key config fields.
 
## Validation
- Searched the updated docs for stale model names, config keys, and old package versions.

