### PR TITLE
feat: wire Copilot SDK provider diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,15 @@ Control the model's reasoning budget (low, medium, or high). Omit to use the mod
 
 Passed as `SessionConfig.ReasoningEffort`. Not all models respect this setting.
 
+### Copilot SDK Diagnostics
+
+Coralph routes Copilot SDK diagnostics into the existing Serilog file sink at `logs/coralph-{date}.log` without writing those SDK logs to the normal console output:
+```bash
+./coralph --copilot-log-level debug
+```
+
+Supported SDK log levels are `all`, `debug`, `info`, `warning`, `error`, and `none`. Omit the option to use the SDK default.
+
 ### Hooks and User-Input Handlers
 
 The Copilot SDK exposes tool hooks through `SessionConfig.Hooks` and user-input callbacks through `SessionConfig.OnUserInputRequest`. Coralph intentionally does not configure them:
@@ -229,11 +238,13 @@ The Copilot SDK exposes tool hooks through `SessionConfig.Hooks` and user-input 
 
 ### OpenAI-Compatible Providers
 
-Use an OpenAI-compatible provider with optional base URL and wire API overrides:
+Use an OpenAI-compatible provider with optional base URL, wire API, model, and token-limit overrides:
 ```bash
 ./coralph --provider-type openai --provider-api-key sk-your-key \
 	--provider-base-url https://api.your-provider.example/v1 \
-	--provider-wire-api openai
+	--provider-wire-api responses \
+	--provider-model-id gpt-5.4 \
+	--provider-max-output-tokens 12000
 ```
 
 ### OpenRouter
@@ -244,9 +255,9 @@ Use an OpenAI-compatible provider with optional base URL and wire API overrides:
 # Minimal usage — model defaults to whatever the Copilot SDK selects
 ./coralph --provider-type openrouter --provider-api-key sk-or-xxxxx
 
-# Select a specific model via --provider-wire-api
+# Select a specific provider model via --provider-wire-model
 ./coralph --provider-type openrouter --provider-api-key sk-or-xxxxx \
-    --provider-wire-api anthropic/claude-3.5-sonnet
+    --provider-wire-model anthropic/claude-3.5-sonnet
 ```
 
 Or via `coralph.config.json`:
@@ -255,7 +266,9 @@ Or via `coralph.config.json`:
   "LoopOptions": {
     "ProviderType": "openrouter",
     "ProviderApiKey": "sk-or-xxxxx",
-    "ProviderWireApi": "anthropic/claude-3.5-sonnet"
+    "ProviderWireModel": "anthropic/claude-3.5-sonnet",
+    "ProviderMaxPromptTokens": 200000,
+    "ProviderMaxOutputTokens": 12000
   }
 }
 ```

--- a/coralph.config.json
+++ b/coralph.config.json
@@ -5,6 +5,10 @@
     "ProviderType": null,
     "ProviderBaseUrl": null,
     "ProviderWireApi": null,
+    "ProviderModelId": null,
+    "ProviderWireModel": null,
+    "ProviderMaxPromptTokens": null,
+    "ProviderMaxOutputTokens": null,
     "ProviderApiKey": null,
     "PromptFile": "prompt.md",
     "ProgressFile": "progress.txt",
@@ -22,6 +26,7 @@
     "ClientName": "coralph",
     "ShowReasoning": true,
     "ColorizedOutput": true,
-    "ReasoningEffort": null
+    "ReasoningEffort": null,
+    "CopilotLogLevel": null
   }
 }

--- a/src/Coralph.Tests/ArgParserTests.cs
+++ b/src/Coralph.Tests/ArgParserTests.cs
@@ -123,6 +123,37 @@ public class ArgParserTests
     }
 
     [Fact]
+    public void Parse_WithProviderOverrideOptions_SetsOverrides()
+    {
+        var (overrides, err, _, _, _, _) = ArgParser.Parse(
+        [
+            "--provider-model-id", "gpt-5.4",
+            "--provider-wire-model", "openrouter/gpt-5.4",
+            "--provider-max-prompt-tokens", "100000",
+            "--provider-max-output-tokens", "12000",
+            "--copilot-log-level", "debug"
+        ]);
+
+        Assert.NotNull(overrides);
+        Assert.Null(err);
+        Assert.Equal("gpt-5.4", overrides.ProviderModelId);
+        Assert.Equal("openrouter/gpt-5.4", overrides.ProviderWireModel);
+        Assert.Equal(100000, overrides.ProviderMaxPromptTokens);
+        Assert.Equal(12000, overrides.ProviderMaxOutputTokens);
+        Assert.Equal("debug", overrides.CopilotLogLevel);
+    }
+
+    [Fact]
+    public void Parse_WithZeroProviderMaxPromptTokens_ReturnsError()
+    {
+        var (overrides, err, _, _, _, _) = ArgParser.Parse(["--provider-max-prompt-tokens", "0"]);
+
+        Assert.Null(overrides);
+        Assert.NotNull(err);
+        Assert.Contains("--provider-max-prompt-tokens", err);
+    }
+
+    [Fact]
     public void Parse_WithEmptyModel_ReturnsError()
     {
         var (overrides, err, _, _, _, _) = ArgParser.Parse(["--model", ""]);
@@ -467,6 +498,10 @@ public class ArgParserTests
         Assert.Contains("--max-iterations", output);
         Assert.Contains("--model", output);
         Assert.Contains("--provider-type", output);
+        Assert.Contains("--provider-model-id", output);
+        Assert.Contains("--provider-wire-model", output);
+        Assert.Contains("--provider-max-prompt-tokens", output);
+        Assert.Contains("--provider-max-output-tokens", output);
         Assert.Contains("--generated-tasks-file", output);
         Assert.Contains("--refresh-issues-azdo", output);
         Assert.Contains("--init", output);
@@ -480,6 +515,7 @@ public class ArgParserTests
         Assert.Contains("--telemetry-otlp-endpoint", output);
         Assert.Contains("--telemetry-source-name", output);
         Assert.Contains("--telemetry-capture-content", output);
+        Assert.Contains("--copilot-log-level", output);
         Assert.Contains("--docker-network", output);
         Assert.Contains("--docker-memory", output);
         Assert.Contains("--docker-cpus", output);
@@ -515,7 +551,12 @@ public class ArgParserTests
         var optionNames = ArgParser.GetRegisteredOptionNames();
 
         Assert.Contains("--client-name", optionNames);
+        Assert.Contains("--provider-model-id", optionNames);
+        Assert.Contains("--provider-wire-model", optionNames);
+        Assert.Contains("--provider-max-prompt-tokens", optionNames);
+        Assert.Contains("--provider-max-output-tokens", optionNames);
         Assert.Contains("--reasoning-effort", optionNames);
+        Assert.Contains("--copilot-log-level", optionNames);
         Assert.Contains("--telemetry-otlp-endpoint", optionNames);
         Assert.Contains("--telemetry-source-name", optionNames);
         Assert.Contains("--telemetry-capture-content", optionNames);

--- a/src/Coralph.Tests/ConfigurationServiceTests.cs
+++ b/src/Coralph.Tests/ConfigurationServiceTests.cs
@@ -117,6 +117,33 @@ public sealed class ConfigurationServiceTests
     }
 
     [Fact]
+    public void Merge_ProviderAndCopilotLogValuesFollowOverridePrecedence()
+    {
+        var cli = new LoopOptionsOverrides
+        {
+            ProviderWireModel = "cli-wire-model",
+            ProviderMaxOutputTokens = 12000,
+            CopilotLogLevel = "debug"
+        };
+        var config = new LoopOptionsOverrides
+        {
+            ProviderModelId = "config-model",
+            ProviderWireModel = "config-wire-model",
+            ProviderMaxPromptTokens = 100000,
+            ProviderMaxOutputTokens = 8000,
+            CopilotLogLevel = "info"
+        };
+
+        var options = ConfigurationService.Merge(cli, config);
+
+        Assert.Equal("config-model", options.ProviderModelId);
+        Assert.Equal("cli-wire-model", options.ProviderWireModel);
+        Assert.Equal(100000, options.ProviderMaxPromptTokens);
+        Assert.Equal(12000, options.ProviderMaxOutputTokens);
+        Assert.Equal("debug", options.CopilotLogLevel);
+    }
+
+    [Fact]
     public void LoadOptions_WithUiModeInConfig_BindsUiMode()
     {
         var tempPath = CreateTempConfig(
@@ -161,6 +188,38 @@ public sealed class ConfigurationServiceTests
             Assert.Equal("http://localhost:4318", options.TelemetryOtlpEndpoint);
             Assert.Equal("coralph-config", options.TelemetrySourceName);
             Assert.True(options.TelemetryCaptureContent);
+        }
+        finally
+        {
+            File.Delete(tempPath);
+        }
+    }
+
+    [Fact]
+    public void LoadOptions_WithProviderOverridesInConfig_BindsProviderOptions()
+    {
+        var tempPath = CreateTempConfig(
+            """
+            {
+              "LoopOptions": {
+                "ProviderModelId": "gpt-5.4",
+                "ProviderWireModel": "openrouter/gpt-5.4",
+                "ProviderMaxPromptTokens": 100000,
+                "ProviderMaxOutputTokens": 12000,
+                "CopilotLogLevel": "warning"
+              }
+            }
+            """);
+
+        try
+        {
+            var options = ConfigurationService.LoadOptions(new LoopOptionsOverrides(), tempPath);
+
+            Assert.Equal("gpt-5.4", options.ProviderModelId);
+            Assert.Equal("openrouter/gpt-5.4", options.ProviderWireModel);
+            Assert.Equal(100000, options.ProviderMaxPromptTokens);
+            Assert.Equal(12000, options.ProviderMaxOutputTokens);
+            Assert.Equal("warning", options.CopilotLogLevel);
         }
         finally
         {

--- a/src/Coralph.Tests/CopilotClientFactoryTests.cs
+++ b/src/Coralph.Tests/CopilotClientFactoryTests.cs
@@ -18,7 +18,8 @@ public class CopilotClientFactoryTests
             CopilotToken = "ghp_test_token",
             TelemetryOtlpEndpoint = "http://localhost:4318",
             TelemetrySourceName = "coralph-test",
-            TelemetryCaptureContent = true
+            TelemetryCaptureContent = true,
+            CopilotLogLevel = "debug"
         };
 
         var clientOptions = CopilotClientFactory.CreateClientOptions(options);
@@ -33,6 +34,8 @@ public class CopilotClientFactoryTests
         Assert.Equal("http://localhost:4318", clientOptions.Telemetry!.OtlpEndpoint);
         Assert.Equal("coralph-test", clientOptions.Telemetry.SourceName);
         Assert.True(clientOptions.Telemetry.CaptureContent);
+        Assert.NotNull(clientOptions.Logger);
+        Assert.Equal(CopilotLogLevel.Debug, clientOptions.LogLevel);
     }
 
     [Fact]
@@ -58,6 +61,8 @@ public class CopilotClientFactoryTests
         Assert.Null(clientOptions.Connection);
         Assert.Null(clientOptions.GitHubToken);
         Assert.Null(clientOptions.Telemetry);
+        Assert.NotNull(clientOptions.Logger);
+        Assert.Null(clientOptions.LogLevel);
     }
 
     [Fact]
@@ -100,6 +105,82 @@ public class CopilotClientFactoryTests
     }
 
     [Fact]
+    public async Task CreateSessionConfig_AutoModeSwitchHandler_ApprovesAndEmitsEvent()
+    {
+        var tools = CustomTools.GetDefaultTools("issues.json", "progress.txt", "generated_tasks.json");
+        var output = new StringWriter();
+        var stream = new EventStreamWriter(output, "event-session");
+        var config = CopilotClientFactory.CreateSessionConfig(new LoopOptions(), tools, PermissionHandler.ApproveAll, eventStream: stream);
+
+        var response = await config.OnAutoModeSwitchRequest!(
+            new AutoModeSwitchRequest
+            {
+                ErrorCode = "rate_limited",
+                RetryAfterSeconds = 2.5
+            },
+            new AutoModeSwitchInvocation
+            {
+                SessionId = "sdk-session"
+            });
+
+        Assert.Equal(AutoModeSwitchResponse.Yes, response);
+        var line = ParseSingleJsonLine(output.ToString());
+        Assert.Equal("auto_mode_switch_request", line.GetProperty("type").GetString());
+        Assert.Equal("sdk-session", line.GetProperty("copilotSessionId").GetString());
+        Assert.Equal("rate_limited", line.GetProperty("errorCode").GetString());
+        Assert.Equal(2.5, line.GetProperty("retryAfterSeconds").GetDouble());
+        Assert.Equal("yes", line.GetProperty("decision").GetString());
+    }
+
+    [Theory]
+    [InlineData(false, true, "apply")]
+    [InlineData(true, false, null)]
+    public async Task CreateSessionConfig_ExitPlanModeHandler_UsesDryRunDecision(
+        bool dryRun,
+        bool expectedApproved,
+        string? expectedSelectedAction)
+    {
+        var tools = CustomTools.GetDefaultTools("issues.json", "progress.txt", "generated_tasks.json");
+        var output = new StringWriter();
+        var stream = new EventStreamWriter(output, "event-session");
+        var config = CopilotClientFactory.CreateSessionConfig(
+            new LoopOptions { DryRun = dryRun },
+            tools,
+            PermissionHandler.ApproveAll,
+            eventStream: stream);
+
+        var result = await config.OnExitPlanModeRequest!(
+            new ExitPlanModeRequest
+            {
+                Summary = "Plan summary",
+                RecommendedAction = "apply",
+                Actions = ["apply", "revise"],
+                PlanContent = "Plan content"
+            },
+            new ExitPlanModeInvocation
+            {
+                SessionId = "sdk-session"
+            });
+
+        Assert.Equal(expectedApproved, result.Approved);
+        Assert.Equal(expectedSelectedAction, result.SelectedAction);
+        if (dryRun)
+        {
+            Assert.Contains("dry-run", result.Feedback, StringComparison.OrdinalIgnoreCase);
+        }
+        else
+        {
+            Assert.Null(result.Feedback);
+        }
+
+        var line = ParseSingleJsonLine(output.ToString());
+        Assert.Equal("exit_plan_mode_request", line.GetProperty("type").GetString());
+        Assert.Equal("sdk-session", line.GetProperty("copilotSessionId").GetString());
+        Assert.Equal(expectedApproved, line.GetProperty("approved").GetBoolean());
+        Assert.Equal(dryRun, line.GetProperty("dryRun").GetBoolean());
+    }
+
+    [Fact]
     public void CreateSessionConfig_WithNullProviderValues_LeavesProviderUnset()
     {
         var tools = CustomTools.GetDefaultTools("issues.json", "progress.txt", "generated_tasks.json");
@@ -111,5 +192,12 @@ public class CopilotClientFactoryTests
         Assert.Null(config.GitHubToken);
         Assert.True(config.IncludeSubAgentStreamingEvents);
         Assert.NotNull(config.SystemMessage);
+    }
+
+    private static System.Text.Json.JsonElement ParseSingleJsonLine(string jsonl)
+    {
+        var line = Assert.Single(jsonl.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries));
+        using var doc = System.Text.Json.JsonDocument.Parse(line);
+        return doc.RootElement.Clone();
     }
 }

--- a/src/Coralph.Tests/DockerSandboxArgumentTests.cs
+++ b/src/Coralph.Tests/DockerSandboxArgumentTests.cs
@@ -40,6 +40,26 @@ public sealed class DockerSandboxArgumentTests : IDisposable
     }
 
     [Fact]
+    public void BuildDockerRunProcessStartInfo_WithProviderOverrides_ForwardsArguments()
+    {
+        var psi = BuildProcessStartInfo(new LoopOptions
+        {
+            ProviderModelId = "gpt-5.4",
+            ProviderWireModel = "openrouter/gpt-5.4",
+            ProviderMaxPromptTokens = 100000,
+            ProviderMaxOutputTokens = 12000,
+            CopilotLogLevel = "debug"
+        });
+
+        var args = psi.ArgumentList.ToArray();
+        AssertArgumentPair(args, "--provider-model-id", "gpt-5.4");
+        AssertArgumentPair(args, "--provider-wire-model", "openrouter/gpt-5.4");
+        AssertArgumentPair(args, "--provider-max-prompt-tokens", "100000");
+        AssertArgumentPair(args, "--provider-max-output-tokens", "12000");
+        AssertArgumentPair(args, "--copilot-log-level", "debug");
+    }
+
+    [Fact]
     public void BuildDockerRunProcessStartInfo_AddsDockerHardeningDefaults()
     {
         var psi = BuildProcessStartInfo(new LoopOptions());

--- a/src/Coralph.Tests/ProviderConfigFactoryTests.cs
+++ b/src/Coralph.Tests/ProviderConfigFactoryTests.cs
@@ -57,7 +57,11 @@ public class ProviderConfigFactoryTests
         {
             ProviderType = "openai",
             ProviderBaseUrl = "https://example.com/api/",
-            ProviderWireApi = "chat"
+            ProviderWireApi = "chat",
+            ProviderModelId = "gpt-5.4",
+            ProviderWireModel = "provider/gpt-5.4",
+            ProviderMaxPromptTokens = 100000,
+            ProviderMaxOutputTokens = 12000
         };
 
         var config = ProviderConfigFactory.Create(options);
@@ -66,6 +70,27 @@ public class ProviderConfigFactoryTests
         Assert.Equal("openai", config.Type);
         Assert.Equal("https://example.com/api/", config.BaseUrl);
         Assert.Equal("chat", config.WireApi);
+        Assert.Equal("gpt-5.4", config.ModelId);
+        Assert.Equal("provider/gpt-5.4", config.WireModel);
+        Assert.Equal(100000, config.MaxPromptTokens);
+        Assert.Equal(12000, config.MaxOutputTokens);
+    }
+
+    [Fact]
+    public void Create_WithOnlyProviderModelOverride_DefaultsToOpenAiProvider()
+    {
+        var options = new LoopOptions
+        {
+            ProviderModelId = "gpt-5.4"
+        };
+
+        var config = ProviderConfigFactory.Create(options);
+
+        Assert.NotNull(config);
+        Assert.Equal("openai", config.Type);
+        Assert.Equal("https://api.openai.com/v1/", config.BaseUrl);
+        Assert.Equal("responses", config.WireApi);
+        Assert.Equal("gpt-5.4", config.ModelId);
     }
 
     [Fact]

--- a/src/Coralph/ArgParser.cs
+++ b/src/Coralph/ArgParser.cs
@@ -42,6 +42,10 @@ internal static class ArgParser
         ApplyRequiredStringOption(result, optionSet.ProviderType, value => options.ProviderType = value, errorMessages, "--provider-type is required");
         ApplyRequiredStringOption(result, optionSet.ProviderBaseUrl, value => options.ProviderBaseUrl = value, errorMessages, "--provider-base-url is required");
         ApplyRequiredStringOption(result, optionSet.ProviderWireApi, value => options.ProviderWireApi = value, errorMessages, "--provider-wire-api is required");
+        ApplyRequiredStringOption(result, optionSet.ProviderModelId, value => options.ProviderModelId = value, errorMessages, "--provider-model-id is required");
+        ApplyRequiredStringOption(result, optionSet.ProviderWireModel, value => options.ProviderWireModel = value, errorMessages, "--provider-wire-model is required");
+        ApplyPositiveIntOption(result.GetValueForOption(optionSet.ProviderMaxPromptTokens), value => options.ProviderMaxPromptTokens = value, errorMessages, "--provider-max-prompt-tokens must be an integer >= 1");
+        ApplyPositiveIntOption(result.GetValueForOption(optionSet.ProviderMaxOutputTokens), value => options.ProviderMaxOutputTokens = value, errorMessages, "--provider-max-output-tokens must be an integer >= 1");
         ApplyRequiredStringOption(result, optionSet.ProviderApiKey, value => options.ProviderApiKey = value, errorMessages, "--provider-api-key is required");
         ApplyRequiredStringOption(result, optionSet.PromptFile, value => options.PromptFile = value, errorMessages, "--prompt-file is required");
         ApplyRequiredStringOption(result, optionSet.ProgressFile, value => options.ProgressFile = value, errorMessages, "--progress-file is required");
@@ -176,6 +180,8 @@ internal static class ArgParser
             options.TelemetryCaptureContent = telemetryCaptureContent.Value;
         }
 
+        ApplyRequiredStringOption(result, optionSet.CopilotLogLevel, value => options.CopilotLogLevel = value.Trim(), errorMessages, "--copilot-log-level must not be empty");
+
         if (result.GetValueForOption(optionSet.DryRun))
         {
             options.DryRun = true;
@@ -256,6 +262,22 @@ internal static class ArgParser
         assign(value);
     }
 
+    private static void ApplyPositiveIntOption(int? value, Action<int> assign, List<string> errorMessages, string errorMessage)
+    {
+        if (!value.HasValue)
+        {
+            return;
+        }
+
+        if (value.Value < 1)
+        {
+            errorMessages.Add(errorMessage);
+            return;
+        }
+
+        assign(value.Value);
+    }
+
     private static string[] NormalizeMultiValueOption(IEnumerable<string> values)
     {
         var results = new List<string>();
@@ -291,6 +313,10 @@ internal static class ArgParser
             ProviderType = new Option<string?>("--provider-type", "Optional: provider type (e.g. openai, openrouter)");
             ProviderBaseUrl = new Option<string?>("--provider-base-url", "Optional: provider base URL (e.g. https://api.openai.com/v1/)");
             ProviderWireApi = new Option<string?>("--provider-wire-api", "Optional: provider wire API (e.g. responses)");
+            ProviderModelId = new Option<string?>("--provider-model-id", "Optional: provider model identifier override");
+            ProviderWireModel = new Option<string?>("--provider-wire-model", "Optional: provider wire model override");
+            ProviderMaxPromptTokens = new Option<int?>("--provider-max-prompt-tokens", "Optional: provider prompt token limit override");
+            ProviderMaxOutputTokens = new Option<int?>("--provider-max-output-tokens", "Optional: provider output token limit override");
             ProviderApiKey = new Option<string?>("--provider-api-key", "Optional: provider API key (e.g. for openrouter: sk-or-...)");
             PromptFile = new Option<string?>("--prompt-file", "Prompt file (default: prompt.md)");
             ProgressFile = new Option<string?>("--progress-file", "Progress file (default: progress.txt)");
@@ -332,6 +358,7 @@ internal static class ArgParser
             TelemetryOtlpEndpoint = new Option<string?>("--telemetry-otlp-endpoint", "Optional: OTLP HTTP endpoint for Copilot SDK telemetry (e.g. http://localhost:4318)");
             TelemetrySourceName = new Option<string?>("--telemetry-source-name", "Optional: source name for Copilot SDK telemetry spans");
             TelemetryCaptureContent = new Option<bool?>("--telemetry-capture-content", "Optional: include prompt/response content in Copilot SDK telemetry");
+            CopilotLogLevel = new Option<string?>("--copilot-log-level", "Optional: Copilot SDK diagnostic log level (all, debug, info, warning, error, none)");
             DryRun = new Option<bool>("--dry-run", "Execute the full loop but prevent any actual file writes or git commits (preview mode)");
         }
 
@@ -343,6 +370,10 @@ internal static class ArgParser
         internal Option<string?> ProviderType { get; }
         internal Option<string?> ProviderBaseUrl { get; }
         internal Option<string?> ProviderWireApi { get; }
+        internal Option<string?> ProviderModelId { get; }
+        internal Option<string?> ProviderWireModel { get; }
+        internal Option<int?> ProviderMaxPromptTokens { get; }
+        internal Option<int?> ProviderMaxOutputTokens { get; }
         internal Option<string?> ProviderApiKey { get; }
         internal Option<string?> PromptFile { get; }
         internal Option<string?> ProgressFile { get; }
@@ -378,6 +409,7 @@ internal static class ArgParser
         internal Option<string?> TelemetryOtlpEndpoint { get; }
         internal Option<string?> TelemetrySourceName { get; }
         internal Option<bool?> TelemetryCaptureContent { get; }
+        internal Option<string?> CopilotLogLevel { get; }
         internal Option<bool> DryRun { get; }
 
         internal IReadOnlyList<Option> AllOptions =>
@@ -390,6 +422,10 @@ internal static class ArgParser
             ProviderType,
             ProviderBaseUrl,
             ProviderWireApi,
+            ProviderModelId,
+            ProviderWireModel,
+            ProviderMaxPromptTokens,
+            ProviderMaxOutputTokens,
             ProviderApiKey,
             PromptFile,
             ProgressFile,
@@ -425,6 +461,7 @@ internal static class ArgParser
             TelemetryOtlpEndpoint,
             TelemetrySourceName,
             TelemetryCaptureContent,
+            CopilotLogLevel,
             DryRun
         ];
 

--- a/src/Coralph/ConfigurationService.cs
+++ b/src/Coralph/ConfigurationService.cs
@@ -58,6 +58,10 @@ internal static class ConfigurationService
             ProviderType = CoalesceNullable(cli.ProviderType, config.ProviderType),
             ProviderBaseUrl = CoalesceNullable(cli.ProviderBaseUrl, config.ProviderBaseUrl),
             ProviderWireApi = CoalesceNullable(cli.ProviderWireApi, config.ProviderWireApi),
+            ProviderModelId = CoalesceNullable(cli.ProviderModelId, config.ProviderModelId),
+            ProviderWireModel = CoalesceNullable(cli.ProviderWireModel, config.ProviderWireModel),
+            ProviderMaxPromptTokens = cli.ProviderMaxPromptTokens ?? config.ProviderMaxPromptTokens ?? defaults.ProviderMaxPromptTokens,
+            ProviderMaxOutputTokens = cli.ProviderMaxOutputTokens ?? config.ProviderMaxOutputTokens ?? defaults.ProviderMaxOutputTokens,
             ProviderApiKey = CoalesceNullable(cli.ProviderApiKey, config.ProviderApiKey),
             PromptFile = Coalesce(cli.PromptFile, config.PromptFile, defaults.PromptFile),
             ProgressFile = Coalesce(cli.ProgressFile, config.ProgressFile, defaults.ProgressFile),
@@ -91,6 +95,7 @@ internal static class ConfigurationService
             TelemetryOtlpEndpoint = CoalesceNullable(cli.TelemetryOtlpEndpoint, config.TelemetryOtlpEndpoint),
             TelemetrySourceName = CoalesceNullable(cli.TelemetrySourceName, config.TelemetrySourceName),
             TelemetryCaptureContent = cli.TelemetryCaptureContent ?? config.TelemetryCaptureContent ?? defaults.TelemetryCaptureContent,
+            CopilotLogLevel = CoalesceNullable(cli.CopilotLogLevel, config.CopilotLogLevel),
             DryRun = cli.DryRun ?? config.DryRun ?? defaults.DryRun
         };
     }

--- a/src/Coralph/CopilotClientFactory.cs
+++ b/src/Coralph/CopilotClientFactory.cs
@@ -13,7 +13,9 @@ internal static class CopilotClientFactory
         var clientOptions = new CopilotClientOptions
         {
             WorkingDirectory = Directory.GetCurrentDirectory(),
-            Telemetry = CreateTelemetryConfig(options)
+            Telemetry = CreateTelemetryConfig(options),
+            Logger = CopilotSdkLogger.Instance,
+            LogLevel = CreateCopilotLogLevel(options.CopilotLogLevel)
         };
 
         if (!string.IsNullOrWhiteSpace(options.CliPath))
@@ -38,8 +40,11 @@ internal static class CopilotClientFactory
         LoopOptions options,
         AIFunction[] tools,
         Func<PermissionRequest, PermissionInvocation, Task<PermissionDecision>> onPermissionRequest,
-        Action<SessionEvent>? onEvent = null)
+        Action<SessionEvent>? onEvent = null,
+        EventStreamWriter? eventStream = null)
     {
+        var modeSwitchHandlers = new CopilotModeSwitchHandlers(options, eventStream);
+
         return new SessionConfig
         {
             Model = options.Model,
@@ -47,6 +52,8 @@ internal static class CopilotClientFactory
             Tools = tools,
             OnPermissionRequest = onPermissionRequest,
             OnEvent = onEvent,
+            OnAutoModeSwitchRequest = modeSwitchHandlers.HandleAutoModeSwitchRequestAsync,
+            OnExitPlanModeRequest = modeSwitchHandlers.HandleExitPlanModeRequestAsync,
             Provider = ProviderConfigFactory.Create(options),
             GitHubToken = string.IsNullOrWhiteSpace(options.CopilotToken) ? null : options.CopilotToken,
             IncludeSubAgentStreamingEvents = true,
@@ -70,6 +77,25 @@ internal static class CopilotClientFactory
             OtlpEndpoint = options.TelemetryOtlpEndpoint,
             SourceName = options.TelemetrySourceName,
             CaptureContent = options.TelemetryCaptureContent
+        };
+    }
+
+    private static CopilotLogLevel? CreateCopilotLogLevel(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        return value.Trim().ToLowerInvariant() switch
+        {
+            "all" => CopilotLogLevel.All,
+            "debug" => CopilotLogLevel.Debug,
+            "error" => CopilotLogLevel.Error,
+            "info" or "information" => CopilotLogLevel.Info,
+            "none" => CopilotLogLevel.None,
+            "warn" or "warning" => CopilotLogLevel.Warning,
+            var custom => new CopilotLogLevel(custom)
         };
     }
 }

--- a/src/Coralph/CopilotModeSwitchHandlers.cs
+++ b/src/Coralph/CopilotModeSwitchHandlers.cs
@@ -1,0 +1,83 @@
+using GitHub.Copilot;
+using Serilog;
+
+namespace Coralph;
+
+internal sealed class CopilotModeSwitchHandlers(LoopOptions options, EventStreamWriter? eventStream)
+{
+    private readonly LoopOptions _options = options ?? throw new ArgumentNullException(nameof(options));
+    private readonly EventStreamWriter? _eventStream = eventStream;
+
+    internal Task<AutoModeSwitchResponse> HandleAutoModeSwitchRequestAsync(
+        AutoModeSwitchRequest request,
+        AutoModeSwitchInvocation invocation)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(invocation);
+
+        Log.Information(
+            "Approving Copilot auto mode switch request for session {SessionId}; error code {ErrorCode}; retry after {RetryAfterSeconds}",
+            invocation.SessionId,
+            request.ErrorCode,
+            request.RetryAfterSeconds);
+
+        _eventStream?.Emit("auto_mode_switch_request", fields: new Dictionary<string, object?>
+        {
+            ["copilotSessionId"] = invocation.SessionId,
+            ["errorCode"] = request.ErrorCode,
+            ["retryAfterSeconds"] = request.RetryAfterSeconds,
+            ["decision"] = "yes"
+        });
+
+        return Task.FromResult(AutoModeSwitchResponse.Yes);
+    }
+
+    internal Task<ExitPlanModeResult> HandleExitPlanModeRequestAsync(
+        ExitPlanModeRequest request,
+        ExitPlanModeInvocation invocation)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(invocation);
+
+        var approved = !_options.DryRun;
+        var selectedAction = approved ? ResolveSelectedAction(request) : null;
+        var feedback = approved
+            ? null
+            : "Dry-run mode is enabled; keep the response as a plan and do not modify files or commit.";
+
+        Log.Information(
+            "Handled Copilot exit plan mode request for session {SessionId}; approved {Approved}; dry run {DryRun}; selected action {SelectedAction}",
+            invocation.SessionId,
+            approved,
+            _options.DryRun,
+            selectedAction);
+
+        _eventStream?.Emit("exit_plan_mode_request", fields: new Dictionary<string, object?>
+        {
+            ["copilotSessionId"] = invocation.SessionId,
+            ["approved"] = approved,
+            ["dryRun"] = _options.DryRun,
+            ["recommendedAction"] = request.RecommendedAction,
+            ["selectedAction"] = selectedAction,
+            ["summary"] = request.Summary,
+            ["actionCount"] = request.Actions?.Count ?? 0
+        });
+
+        return Task.FromResult(new ExitPlanModeResult
+        {
+            Approved = approved,
+            Feedback = feedback,
+            SelectedAction = selectedAction
+        });
+    }
+
+    private static string? ResolveSelectedAction(ExitPlanModeRequest request)
+    {
+        if (!string.IsNullOrWhiteSpace(request.RecommendedAction))
+        {
+            return request.RecommendedAction;
+        }
+
+        return request.Actions?.FirstOrDefault(action => !string.IsNullOrWhiteSpace(action));
+    }
+}

--- a/src/Coralph/CopilotRunner.cs
+++ b/src/Coralph/CopilotRunner.cs
@@ -25,7 +25,7 @@ internal static class CopilotRunner
             // Coralph runs unattended; models must not prompt for user input during a loop iteration.
             // Tool-use events are captured by CopilotSessionEventRouter via SessionConfig.OnEvent.
             await using (var session = await client.CreateSessionAsync(
-                CopilotClientFactory.CreateSessionConfig(opt, customTools, permissionPolicy.HandleAsync, router.HandleEvent)))
+                CopilotClientFactory.CreateSessionConfig(opt, customTools, permissionPolicy.HandleAsync, router.HandleEvent, eventStream)))
             {
                 var state = router.StartTurn(turn);
                 using var cancelRegistration = ct.Register(() =>

--- a/src/Coralph/CopilotSdkLogger.cs
+++ b/src/Coralph/CopilotSdkLogger.cs
@@ -1,0 +1,76 @@
+using Microsoft.Extensions.Logging;
+using Serilog;
+using Serilog.Events;
+using MicrosoftLogger = Microsoft.Extensions.Logging.ILogger;
+
+namespace Coralph;
+
+internal sealed class CopilotSdkLogger : MicrosoftLogger
+{
+    internal static readonly MicrosoftLogger Instance = new CopilotSdkLogger();
+
+    private readonly Serilog.ILogger _logger = Serilog.Log.ForContext("SourceContext", "GitHub.Copilot.SDK");
+
+    private CopilotSdkLogger()
+    {
+    }
+
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+
+    public bool IsEnabled(LogLevel logLevel)
+    {
+        var serilogLevel = MapLevel(logLevel);
+        return serilogLevel.HasValue && _logger.IsEnabled(serilogLevel.Value);
+    }
+
+    public void Log<TState>(
+        LogLevel logLevel,
+        EventId eventId,
+        TState state,
+        Exception? exception,
+        Func<TState, Exception?, string> formatter)
+    {
+        ArgumentNullException.ThrowIfNull(formatter);
+
+        var serilogLevel = MapLevel(logLevel);
+        if (!serilogLevel.HasValue)
+        {
+            return;
+        }
+
+        var message = formatter(state, exception);
+        if (string.IsNullOrWhiteSpace(message) && exception is null)
+        {
+            return;
+        }
+
+        _logger
+            .ForContext("CopilotSdkEventId", eventId.Id)
+            .ForContext("CopilotSdkEventName", eventId.Name)
+            .Write(serilogLevel.Value, exception, "Copilot SDK: {CopilotSdkMessage}", message);
+    }
+
+    private static LogEventLevel? MapLevel(LogLevel logLevel)
+    {
+        return logLevel switch
+        {
+            LogLevel.Trace => LogEventLevel.Verbose,
+            LogLevel.Debug => LogEventLevel.Debug,
+            LogLevel.Information => LogEventLevel.Information,
+            LogLevel.Warning => LogEventLevel.Warning,
+            LogLevel.Error => LogEventLevel.Error,
+            LogLevel.Critical => LogEventLevel.Fatal,
+            LogLevel.None => null,
+            _ => LogEventLevel.Information
+        };
+    }
+
+    private sealed class NullScope : IDisposable
+    {
+        internal static readonly NullScope Instance = new();
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/src/Coralph/CopilotSessionRunner.cs
+++ b/src/Coralph/CopilotSessionRunner.cs
@@ -43,7 +43,7 @@ internal sealed class CopilotSessionRunner : IAsyncDisposable
             // Coralph runs unattended; models must not prompt for user input during a loop iteration.
             // Tool-use events are captured by CopilotSessionEventRouter via SessionConfig.OnEvent.
             session = await client.CreateSessionAsync(
-                CopilotClientFactory.CreateSessionConfig(opt, customTools, permissionPolicy.HandleAsync, router.HandleEvent));
+                CopilotClientFactory.CreateSessionConfig(opt, customTools, permissionPolicy.HandleAsync, router.HandleEvent, eventStream));
 
             return new CopilotSessionRunner(client, session, router, started);
         }

--- a/src/Coralph/DockerSandbox.cs
+++ b/src/Coralph/DockerSandbox.cs
@@ -1,5 +1,6 @@
 using System.Buffers;
 using System.Diagnostics;
+using System.Globalization;
 using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -239,6 +240,36 @@ internal static class DockerSandbox
         {
             psi.ArgumentList.Add("--provider-wire-api");
             psi.ArgumentList.Add(opt.ProviderWireApi);
+        }
+
+        if (!string.IsNullOrWhiteSpace(opt.ProviderModelId))
+        {
+            psi.ArgumentList.Add("--provider-model-id");
+            psi.ArgumentList.Add(opt.ProviderModelId);
+        }
+
+        if (!string.IsNullOrWhiteSpace(opt.ProviderWireModel))
+        {
+            psi.ArgumentList.Add("--provider-wire-model");
+            psi.ArgumentList.Add(opt.ProviderWireModel);
+        }
+
+        if (opt.ProviderMaxPromptTokens.HasValue)
+        {
+            psi.ArgumentList.Add("--provider-max-prompt-tokens");
+            psi.ArgumentList.Add(opt.ProviderMaxPromptTokens.Value.ToString(CultureInfo.InvariantCulture));
+        }
+
+        if (opt.ProviderMaxOutputTokens.HasValue)
+        {
+            psi.ArgumentList.Add("--provider-max-output-tokens");
+            psi.ArgumentList.Add(opt.ProviderMaxOutputTokens.Value.ToString(CultureInfo.InvariantCulture));
+        }
+
+        if (!string.IsNullOrWhiteSpace(opt.CopilotLogLevel))
+        {
+            psi.ArgumentList.Add("--copilot-log-level");
+            psi.ArgumentList.Add(opt.CopilotLogLevel);
         }
 
         return psi;

--- a/src/Coralph/LoopOptions.cs
+++ b/src/Coralph/LoopOptions.cs
@@ -13,6 +13,10 @@ internal sealed class LoopOptions
     public string? ProviderType { get; set; }
     public string? ProviderBaseUrl { get; set; }
     public string? ProviderWireApi { get; set; }
+    public string? ProviderModelId { get; set; }
+    public string? ProviderWireModel { get; set; }
+    public int? ProviderMaxPromptTokens { get; set; }
+    public int? ProviderMaxOutputTokens { get; set; }
     public string? ProviderApiKey { get; set; }
 
     public string PromptFile { get; set; } = "prompt.md";
@@ -51,6 +55,7 @@ internal sealed class LoopOptions
     public string? TelemetryOtlpEndpoint { get; set; }
     public string? TelemetrySourceName { get; set; }
     public bool? TelemetryCaptureContent { get; set; }
+    public string? CopilotLogLevel { get; set; }
     public bool DryRun { get; set; }
 }
 
@@ -63,6 +68,10 @@ internal sealed class LoopOptionsOverrides
     public string? ProviderType { get; set; }
     public string? ProviderBaseUrl { get; set; }
     public string? ProviderWireApi { get; set; }
+    public string? ProviderModelId { get; set; }
+    public string? ProviderWireModel { get; set; }
+    public int? ProviderMaxPromptTokens { get; set; }
+    public int? ProviderMaxOutputTokens { get; set; }
     public string? ProviderApiKey { get; set; }
 
     public string? PromptFile { get; set; }
@@ -101,5 +110,6 @@ internal sealed class LoopOptionsOverrides
     public string? TelemetryOtlpEndpoint { get; set; }
     public string? TelemetrySourceName { get; set; }
     public bool? TelemetryCaptureContent { get; set; }
+    public string? CopilotLogLevel { get; set; }
     public bool? DryRun { get; set; }
 }

--- a/src/Coralph/ProviderConfigFactory.cs
+++ b/src/Coralph/ProviderConfigFactory.cs
@@ -24,9 +24,20 @@ internal static class ProviderConfigFactory
         var hasType = !string.IsNullOrWhiteSpace(options.ProviderType);
         var hasBaseUrl = !string.IsNullOrWhiteSpace(options.ProviderBaseUrl);
         var hasWireApi = !string.IsNullOrWhiteSpace(options.ProviderWireApi);
+        var hasModelId = !string.IsNullOrWhiteSpace(options.ProviderModelId);
+        var hasWireModel = !string.IsNullOrWhiteSpace(options.ProviderWireModel);
+        var hasMaxPromptTokens = options.ProviderMaxPromptTokens.HasValue;
+        var hasMaxOutputTokens = options.ProviderMaxOutputTokens.HasValue;
         var hasApiKey = !string.IsNullOrWhiteSpace(apiKey);
 
-        if (!hasType && !hasBaseUrl && !hasWireApi && !hasApiKey)
+        if (!hasType &&
+            !hasBaseUrl &&
+            !hasWireApi &&
+            !hasModelId &&
+            !hasWireModel &&
+            !hasMaxPromptTokens &&
+            !hasMaxOutputTokens &&
+            !hasApiKey)
         {
             return null;
         }
@@ -65,6 +76,10 @@ internal static class ProviderConfigFactory
             Type = type,
             BaseUrl = baseUrl ?? string.Empty,
             WireApi = wireApi,
+            ModelId = options.ProviderModelId,
+            WireModel = options.ProviderWireModel,
+            MaxPromptTokens = options.ProviderMaxPromptTokens,
+            MaxOutputTokens = options.ProviderMaxOutputTokens,
             ApiKey = apiKey
         };
     }


### PR DESCRIPTION
## Summary

- Wire Copilot SDK auto-mode and exit-plan-mode handlers for unattended runs, including dry-run-specific plan-mode behavior and JSON event/log fields.
- Expose provider model and token-limit overrides through CLI, config, Docker forwarding, and provider config mapping.
- Route Copilot SDK diagnostics into Coralph's Serilog file sink with optional `--copilot-log-level` mapping.
- Update README and `coralph.config.json` examples for the new provider and diagnostic options.

Closes #141
Closes #142
Closes #143

## Validation

- `dotnet format --verify-no-changes`
- `just ci` (build: 0 warnings, 0 errors; tests: 318 passed)
